### PR TITLE
Never 404

### DIFF
--- a/besticon/iconserver/server.go
+++ b/besticon/iconserver/server.go
@@ -79,11 +79,7 @@ func iconHandler(w http.ResponseWriter, r *http.Request) {
 		finder.FormatsAllowed = strings.Split(r.FormValue("formats"), ",")
 	}
 
-	err, _ = finder.FetchIcons(url)
-	if err != nil {
-		writeAPIError(w, 404, err, true)
-		return
-	}
+	finder.FetchIcons(url)
 
 	icon := finder.IconWithMinSize(minSize)
 	if icon != nil {

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -72,6 +72,19 @@ func TestGetIconWithFallBackURL(t *testing.T) {
 	assertStringEquals(t, "http://example.com", w.Header().Get("Location"))
 }
 
+func TestGetIconWith404Page(t *testing.T) {
+	req, err := http.NewRequest("GET", "/icons?size=32&url=httpbin.org/status/404", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	iconHandler(w, req)
+
+	assertStringEquals(t, "302", fmt.Sprintf("%d", w.Code))
+	assertStringEquals(t, "/lettericons/H-32.png", w.Header().Get("Location"))
+}
+
 func TestGetAllIcons(t *testing.T) {
 	req, err := http.NewRequest("GET", "/allicons.json?url=apple.com", nil)
 	if err != nil {

--- a/lettericon/lettericon.go
+++ b/lettericon/lettericon.go
@@ -232,7 +232,7 @@ func ParseIconPath(fullpath string) (string, *color.RGBA, int) {
 
 func MainLetterFromURL(URL string) string {
 	URL = strings.TrimSpace(URL)
-	if !strings.HasPrefix(URL, "http") {
+	if !strings.HasPrefix(URL, "http:") && !strings.HasPrefix(URL, "https:") {
 		URL = "http://" + URL
 	}
 

--- a/lettericon/lettericon_test.go
+++ b/lettericon/lettericon_test.go
@@ -115,6 +115,8 @@ func TestMainLetterFromURL(t *testing.T) {
 
 	assertEquals(t, "s", MainLetterFromURL("some-user.blogspot.com"))
 	assertEquals(t, "b", MainLetterFromURL("blogspot.com"))
+
+	assertEquals(t, "h", MainLetterFromURL("httpbin.org"))
 }
 
 func TestIconPath(t *testing.T) {


### PR DESCRIPTION
Hey, thanks for the awesome project! One thing that I've run into with favicons is that I always want to show an icon, so rendering 404 doesn't help me. Initially I assumed fallback_image_url would do the trick, but it only worked if the size doesn't match. So I made a change, and now I'm PR'ing it here to start a discussion.

What's your take on this? It could also be hidden behind a flag, to always just fall back to the letter icons if no icon can be parsed. 