### PR TITLE
Add fallback_icon_color query parameter to API.

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -28,6 +28,7 @@ url       | http://yelp.com |                                   | required
 size      | 120             | Desired **minimum** icon size | required
 formats   | png,ico         | Comma-separated list of accepted image formats: png, ico, gif | `png,ico,gif`
 fallback\_icon\_url   | *HTTP image URL*         | If provided, a redirect to this image will be returned in case no suitable icon could be found. This overrides the default fallback image behaviour.  |
+colorize\_letters | *flag* | If provided, letter icons will be colored arbitrarily, rather than be grey, when no color can be found for any icon.
 
 
 #### Examples
@@ -38,6 +39,7 @@ fallback\_icon\_url   | *HTTP image URL*         | If provided, a redirect to th
 |<https://icons.better-idea.org/icon?url=yelp.com&size=64>|![Icon for yelp.com](https://icons.better-idea.org/icon?url=yelp.com&size=64)|
 |<https://icons.better-idea.org/icon?url=yelp.com>|size missing|
 |<https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64>|![Icon for non-existent page](https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64)|
+|<https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64&colorize_letters>|![Icon for non-existent page](https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64&colorize_letters)|
 |<https://icons.better-idea.org/icon?url=фминобрнауки.рф&size=32>|![Icon with cyrillic letter ф](https://icons.better-idea.org/icon?url=фминобрнауки.рф&size=32)|
 
 

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -120,6 +120,7 @@ Package | Description | License
 ## Contributors
 
   * Erkie - https://github.com/erkie
+  * mmkal - https://github.com/mmkal
 
 ## License
 

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -28,7 +28,7 @@ url       | http://yelp.com |                                   | required
 size      | 120             | Desired **minimum** icon size | required
 formats   | png,ico         | Comma-separated list of accepted image formats: png, ico, gif | `png,ico,gif`
 fallback\_icon\_url   | *HTTP image URL*         | If provided, a redirect to this image will be returned in case no suitable icon could be found. This overrides the default fallback image behaviour.  |
-colorize\_letters | *flag* | If provided, letter icons will be colored arbitrarily, rather than be grey, when no color can be found for any icon.
+fallback\_icon\_color | ff0000 | If provided, letter icons will be colored with the hex value provided, rather than be grey, when no color can be found for any icon.
 
 
 #### Examples
@@ -39,7 +39,7 @@ colorize\_letters | *flag* | If provided, letter icons will be colored arbitrari
 |<https://icons.better-idea.org/icon?url=yelp.com&size=64>|![Icon for yelp.com](https://icons.better-idea.org/icon?url=yelp.com&size=64)|
 |<https://icons.better-idea.org/icon?url=yelp.com>|size missing|
 |<https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64>|![Icon for non-existent page](https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64)|
-|<https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64&colorize_letters>|![Icon for non-existent page](https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64&colorize_letters)|
+|<https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64&fallback_icon_color=ff0000>|![Icon for non-existent page](https://icons.better-idea.org/icon?url=httpbin.org/status/404&size=64&fallback_icon_color=ff0000)|
 |<https://icons.better-idea.org/icon?url=фминобрнауки.рф&size=32>|![Icon with cyrillic letter ф](https://icons.better-idea.org/icon?url=фминобрнауки.рф&size=32)|
 
 

--- a/besticon/iconserver/server.go
+++ b/besticon/iconserver/server.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
+	"hash/fnv"
 	"html/template"
+	"image/color"
 	"net/http"
 	"net/url"
 	"os"
@@ -98,8 +101,31 @@ func iconHandler(w http.ResponseWriter, r *http.Request) {
 
 	iconColor := finder.MainColorForIcons()
 	letter := lettericon.MainLetterFromURL(url)
-	redirectPath := lettericon.IconPath(letter, size, iconColor)
+
+	var redirectPath string
+
+	if iconColor == nil && r.URL.Query()["colorize_letters"] != nil {
+		redirectPath = lettericon.IconPath(letter, size, getColorBasedOnURLHash(url)) + "#colorized"
+	} else {
+		redirectPath = lettericon.IconPath(letter, size, iconColor)
+	}
+
 	redirectWithCacheControl(w, r, redirectPath)
+}
+
+func getColorBasedOnURLHash(url string) *color.RGBA {
+	hash := fnv.New32a()
+	hash.Write([]byte(url))
+	hashHex := hex.EncodeToString(hash.Sum(nil))
+	if len(hashHex) < 6 {
+		hashHex = "000000" + hashHex
+	}
+	endOfHashHex := hashHex[len(hashHex)-6 : len(hashHex)]
+	colorFromHex, err := lettericon.ColorFromHex(endOfHashHex)
+	if err != nil {
+		return nil
+	}
+	return colorFromHex
 }
 
 func popularHandler(w http.ResponseWriter, r *http.Request) {

--- a/besticon/iconserver/server.go
+++ b/besticon/iconserver/server.go
@@ -109,7 +109,6 @@ func iconHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	redirectPath := lettericon.IconPath(letter, size, iconColor)
-
 	redirectWithCacheControl(w, r, redirectPath)
 }
 

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -88,6 +88,35 @@ func TestGetIconWith404Page(t *testing.T) {
 	assertStringEquals(t, "/lettericons/H-32.png", w.Header().Get("Location"))
 }
 
+func TestGetColorizedLetterIcon(t *testing.T) {
+	req, err := http.NewRequest("GET", "/icons?size=32&url=httpbin.org/status/404&colorize_letters", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	iconHandler(w, req)
+
+	assertStringEquals(t, "302", fmt.Sprintf("%d", w.Code))
+	assertStringStartsWith(t, w.Header().Get("Location"), "/lettericons/H")
+	assertStringEndsWith(t, w.Header().Get("Location"), "#colorized")
+}
+
+func TestGetUncolorizedLetterIcon(t *testing.T) {
+	// Apple has a .png apple touch icon, so even if we request an icon bigger than apple.com provides, the color from the png should be used
+	req, err := http.NewRequest("GET", "/icons?size=160&url=apple.com&colorize_letters", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	iconHandler(w, req)
+
+	assertStringEquals(t, "302", fmt.Sprintf("%d", w.Code))
+	assertStringStartsWith(t, w.Header().Get("Location"), "/lettericons/A-160")
+	assertStringEndsWith(t, w.Header().Get("Location"), ".png")
+}
+
 func TestGetAllIcons(t *testing.T) {
 	req, err := http.NewRequest("GET", "/allicons.json?url=apple.com", nil)
 	if err != nil {
@@ -170,6 +199,18 @@ func TestGet404(t *testing.T) {
 func assertStringContains(t *testing.T, haystack string, needle string) {
 	if !strings.Contains(haystack, needle) {
 		fail(t, fmt.Sprintf("Expected '%s' to be contained in '%s'", needle, haystack))
+	}
+}
+
+func assertStringStartsWith(t *testing.T, haystack string, needle string) {
+	if !strings.HasPrefix(haystack, needle) {
+		fail(t, fmt.Sprintf("Expected '%s' to be a prefix of '%s'", needle, haystack))
+	}
+}
+
+func assertStringEndsWith(t *testing.T, haystack string, needle string) {
+	if !strings.HasSuffix(haystack, needle) {
+		fail(t, fmt.Sprintf("Expected '%s' to be a suffix of '%s'", needle, haystack))
 	}
 }
 

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -102,7 +102,7 @@ func TestGet404IconWithFallbackColor(t *testing.T) {
 }
 
 func TestGet404IconWithInvalidFallbackColor(t *testing.T) {
-	req, err := http.NewRequest("GET", "/icons?size=32&url=httpbin.org/status/404?fallback_icon_color=zz", nil)
+	req, err := http.NewRequest("GET", "/icons?size=32&url=httpbin.org/status/404&fallback_icon_color=zz", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -88,8 +88,8 @@ func TestGetIconWith404Page(t *testing.T) {
 	assertStringEquals(t, "/lettericons/H-32.png", w.Header().Get("Location"))
 }
 
-func TestGetColorizedLetterIcon(t *testing.T) {
-	req, err := http.NewRequest("GET", "/icons?size=32&url=httpbin.org/status/404&colorize_letters", nil)
+func TestGet404IconWithFallbackColor(t *testing.T) {
+	req, err := http.NewRequest("GET", "/icons?size=32&url=httpbin.org/status/404&fallback_icon_color=123456", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -98,13 +98,11 @@ func TestGetColorizedLetterIcon(t *testing.T) {
 	iconHandler(w, req)
 
 	assertStringEquals(t, "302", fmt.Sprintf("%d", w.Code))
-	assertStringStartsWith(t, w.Header().Get("Location"), "/lettericons/H")
-	assertStringEndsWith(t, w.Header().Get("Location"), "#colorized")
+	assertStringEquals(t, "/lettericons/H-32-123456.png", w.Header().Get("Location"))
 }
 
-func TestGetUncolorizedLetterIcon(t *testing.T) {
-	// Apple has a .png apple touch icon, so even if we request an icon bigger than apple.com provides, the color from the png should be used
-	req, err := http.NewRequest("GET", "/icons?size=160&url=apple.com&colorize_letters", nil)
+func TestGet404IconWithInvalidFallbackColor(t *testing.T) {
+	req, err := http.NewRequest("GET", "/icons?size=32&url=httpbin.org/status/404?fallback_icon_color=zz", nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -113,8 +111,7 @@ func TestGetUncolorizedLetterIcon(t *testing.T) {
 	iconHandler(w, req)
 
 	assertStringEquals(t, "302", fmt.Sprintf("%d", w.Code))
-	assertStringStartsWith(t, w.Header().Get("Location"), "/lettericons/A-160")
-	assertStringEndsWith(t, w.Header().Get("Location"), ".png")
+	assertStringEquals(t, "/lettericons/H-32.png", w.Header().Get("Location"))
 }
 
 func TestGetAllIcons(t *testing.T) {
@@ -199,18 +196,6 @@ func TestGet404(t *testing.T) {
 func assertStringContains(t *testing.T, haystack string, needle string) {
 	if !strings.Contains(haystack, needle) {
 		fail(t, fmt.Sprintf("Expected '%s' to be contained in '%s'", needle, haystack))
-	}
-}
-
-func assertStringStartsWith(t *testing.T, haystack string, needle string) {
-	if !strings.HasPrefix(haystack, needle) {
-		fail(t, fmt.Sprintf("Expected '%s' to be a prefix of '%s'", needle, haystack))
-	}
-}
-
-func assertStringEndsWith(t *testing.T, haystack string, needle string) {
-	if !strings.HasSuffix(haystack, needle) {
-		fail(t, fmt.Sprintf("Expected '%s' to be a suffix of '%s'", needle, haystack))
 	}
 }
 


### PR DESCRIPTION
If provided in the query parameters, this will use a hash of the URL passed in to color the letter icon used. The color is used when there is no icon of the requested size, and no "main color" could be found in smaller icons.

The idea is that this will prevent so many icons being grey when a large icon size is requested.