### PR TITLE
correct logic in perfect..min size search

### DIFF
--- a/besticon/besticon.go
+++ b/besticon/besticon.go
@@ -109,10 +109,10 @@ func (f *IconFinder) IconInSizeRange(r SizeRange) *Icon {
 		}
 	}
 
-	// Try to return biggest in range perfect..min
+	// Try to return biggest in range min..max
 	sortIcons(icons, true)
 	for _, ico := range icons {
-		if ico.Width >= r.Min && ico.Height >= r.Min {
+		if (ico.Width >= r.Min && ico.Height >= r.Min) && (ico.Width <= r.Max && ico.Height <= r.Max) {
 			return &ico
 		}
 	}

--- a/besticon/besticon.go
+++ b/besticon/besticon.go
@@ -109,10 +109,10 @@ func (f *IconFinder) IconInSizeRange(r SizeRange) *Icon {
 		}
 	}
 
-	// Try to return biggest in range min..max
+	// Try to return biggest in range perfect..min
 	sortIcons(icons, true)
 	for _, ico := range icons {
-		if (ico.Width >= r.Min && ico.Height >= r.Min) && (ico.Width <= r.Max && ico.Height <= r.Max) {
+		if (ico.Width >= r.Min && ico.Height >= r.Min) && (ico.Width <= r.Perfect && ico.Height <= r.Perfect) {
 			return &ico
 		}
 	}


### PR DESCRIPTION
I believe I found the error in your logic for determining the correct min size. You have a comment there that describes what you wanted, but the logic did not match.

The current code does not compare against the max or perfect range when searching for the biggest icon that is `>` min. Since the icons are sorted in descending order for this iterator, you will always get the largest icon from the list (which is the first one in the for loop). This confirms the behavior I am seeing in #28.

Note: I am not a go developer and I was not able to run and test this code. I do, however, know how to read boolean logic 😃  . Please double check my work and syntax (I just copy/pasted and tweaked from the above logic).

resolves #28 