### PR TITLE
Extraction

### DIFF
--- a/besticon/besticon_test.go
+++ b/besticon/besticon_test.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/mat/besticon/vcr"
@@ -199,14 +198,6 @@ func TestParsingEmptyResponse(t *testing.T) {
 	assertEquals(t, errors.New("besticon: empty response"), err)
 }
 
-func mustFindIconLinks(html []byte) []string {
-	doc, e := docFromHTML(html)
-	check(e)
-	links := extractIconTags(doc)
-	sort.Strings(links)
-	return links
-}
-
 func TestMainColorForIconsWithBrokenImageData(t *testing.T) {
 	icn := Icon{Format: "png", ImageData: []byte("broken-image-data")}
 	colr := MainColorForIcons([]Icon{icn})
@@ -216,24 +207,6 @@ func TestMainColorForIconsWithBrokenImageData(t *testing.T) {
 func TestFindBestIconNoIcons(t *testing.T) {
 	icons, _, _ := fetchIconsWithVCR("example.com.vcr", "http://example.com")
 	assertEquals(t, 0, len(icons))
-}
-
-func TestLinkExtraction(t *testing.T) {
-	links := mustFindIconLinks(mustReadFile("testdata/daringfireball.html"))
-	assertEquals(t, []string{
-		"/graphics/apple-touch-icon.png",
-		"/graphics/favicon.ico?v=005",
-	}, links)
-
-	links = mustFindIconLinks(mustReadFile("testdata/newyorker.html"))
-	assertEquals(t, []string{
-		"/wp-content/assets/dist/img/icon/apple-touch-icon-114x114-precomposed.png",
-		"/wp-content/assets/dist/img/icon/apple-touch-icon-144x144-precomposed.png",
-		"/wp-content/assets/dist/img/icon/apple-touch-icon-57x57-precomposed.png",
-		"/wp-content/assets/dist/img/icon/apple-touch-icon-precomposed.png",
-		"/wp-content/assets/dist/img/icon/apple-touch-icon.png",
-		"/wp-content/assets/dist/img/icon/favicon.ico",
-	}, links)
 }
 
 func TestImageSizeDetection(t *testing.T) {

--- a/besticon/extract.go
+++ b/besticon/extract.go
@@ -1,0 +1,158 @@
+// Package besticon includes functions
+// finding icons for a given web site.
+package besticon
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+var iconPaths = []string{
+	"/favicon.ico",
+	"/apple-touch-icon.png",
+	"/apple-touch-icon-precomposed.png",
+}
+
+const (
+	favIcon                   = "icon"
+	appleTouchIcon            = "apple-touch-icon"
+	appleTouchIconPrecomposed = "apple-touch-icon-precomposed"
+)
+
+type empty struct{}
+
+// Find all icons in this html. We use siteURL as the base url unless we detect
+// another base url in <head>
+func findIconLinks(siteURL *url.URL, html []byte) ([]string, error) {
+	doc, e := docFromHTML(html)
+	if e != nil {
+		return nil, e
+	}
+
+	baseURL := determineBaseURL(siteURL, doc)
+
+	// Use a map to avoid dups
+	links := make(map[string]empty)
+
+	// Add common, hard coded icon paths
+	for _, path := range iconPaths {
+		links[urlFromBase(baseURL, path)] = empty{}
+	}
+
+	// Add icons found in page
+	urls := extractIconTags(doc)
+	for _, u := range urls {
+		absoluteURL, e := absoluteURL(baseURL, u)
+		if e == nil {
+			links[absoluteURL] = empty{}
+		}
+	}
+
+	// Turn unique keys into array
+	var result []string
+	for u := range links {
+		result = append(result, u)
+	}
+	sort.Strings(result)
+
+	return result, nil
+}
+
+// What is the baseURL for this doc?
+func determineBaseURL(siteURL *url.URL, doc *goquery.Document) *url.URL {
+	baseTagHref := extractBaseTag(doc)
+	if baseTagHref != "" {
+		baseTagURL, e := url.Parse(baseTagHref)
+		if e != nil {
+			return siteURL
+		}
+		return baseTagURL
+	}
+
+	return siteURL
+}
+
+// Convert bytes => doc
+func docFromHTML(html []byte) (*goquery.Document, error) {
+	doc, e := goquery.NewDocumentFromReader(bytes.NewReader(html))
+	if e != nil || doc == nil {
+		return nil, errParseHTML
+	}
+	return doc, nil
+}
+
+// List of css selectors for icons
+var csspaths = strings.Join([]string{
+	"link[rel='icon']",
+	"link[rel='shortcut icon']",
+	"link[rel='apple-touch-icon']",
+	"link[rel='apple-touch-icon-precomposed']",
+
+	// Capitalized variants, TODO: refactor
+	"link[rel='ICON']",
+	"link[rel='SHORTCUT ICON']",
+	"link[rel='APPLE-TOUCH-ICON']",
+	"link[rel='APPLE-TOUCH-ICON-PRECOMPOSED']",
+}, ", ")
+
+var errParseHTML = errors.New("besticon: could not parse html")
+
+// Find <head><base href="xxx">
+func extractBaseTag(doc *goquery.Document) string {
+	href := ""
+	doc.Find("head base[href]").First().Each(func(i int, s *goquery.Selection) {
+		href, _ = s.Attr("href")
+	})
+	return href
+}
+
+var (
+	iconTypes   = []string{favIcon, appleTouchIcon, appleTouchIconPrecomposed}
+	iconTypesRe = regexp.MustCompile(fmt.Sprintf(`\b(%s)\b`, strings.Join(iconTypes, "|")))
+)
+
+// Find icons from doc using csspaths
+func extractIconTags(doc *goquery.Document) []string {
+	var hits []string
+	doc.Find("link[href][rel]").Each(func(i int, s *goquery.Selection) {
+		href := extractIconTag(s)
+		if href != "" {
+			hits = append(hits, href)
+		}
+	})
+	return hits
+}
+
+func extractIconTag(s *goquery.Selection) string {
+	// What sort of iconType is in this <rel>?
+	rel, _ := s.Attr("rel")
+	if rel == "" {
+		return ""
+	}
+	rel = strings.ToLower(rel)
+
+	var iconType string
+	for _, i := range strings.Split(rel, " ") {
+		if iconTypesRe.MatchString(i) {
+			iconType = i
+			break
+		}
+	}
+	if iconType == "" {
+		return ""
+	}
+
+	href, _ := s.Attr("href")
+	if href == "" {
+		return ""
+	}
+
+	return href
+}

--- a/besticon/extract.go
+++ b/besticon/extract.go
@@ -99,7 +99,7 @@ func extractBaseTag(doc *goquery.Document) string {
 
 var (
 	iconTypes   = []string{favIcon, appleTouchIcon, appleTouchIconPrecomposed}
-	iconTypesRe = regexp.MustCompile(fmt.Sprintf(`\b(%s)\b`, strings.Join(iconTypes, "|")))
+	iconTypesRe = regexp.MustCompile(fmt.Sprintf(`\b(%s)\b`, strings.Join(regexpQuoteMetaArray(iconTypes), "|")))
 )
 
 // Find icons from doc using goquery
@@ -139,4 +139,13 @@ func extractIconTag(s *goquery.Selection) string {
 	}
 
 	return href
+}
+
+// regexp.QuoteMeta an array of strings
+func regexpQuoteMetaArray(a []string) []string {
+	quoted := make([]string, len(a))
+	for i, s := range a {
+		quoted[i] = regexp.QuoteMeta(s)
+	}
+	return quoted
 }

--- a/besticon/extract.go
+++ b/besticon/extract.go
@@ -1,5 +1,3 @@
-// Package besticon includes functions
-// finding icons for a given web site.
 package besticon
 
 import (

--- a/besticon/extract.go
+++ b/besticon/extract.go
@@ -86,20 +86,6 @@ func docFromHTML(html []byte) (*goquery.Document, error) {
 	return doc, nil
 }
 
-// List of css selectors for icons
-var csspaths = strings.Join([]string{
-	"link[rel='icon']",
-	"link[rel='shortcut icon']",
-	"link[rel='apple-touch-icon']",
-	"link[rel='apple-touch-icon-precomposed']",
-
-	// Capitalized variants, TODO: refactor
-	"link[rel='ICON']",
-	"link[rel='SHORTCUT ICON']",
-	"link[rel='APPLE-TOUCH-ICON']",
-	"link[rel='APPLE-TOUCH-ICON-PRECOMPOSED']",
-}, ", ")
-
 var errParseHTML = errors.New("besticon: could not parse html")
 
 // Find <head><base href="xxx">
@@ -116,7 +102,7 @@ var (
 	iconTypesRe = regexp.MustCompile(fmt.Sprintf(`\b(%s)\b`, strings.Join(iconTypes, "|")))
 )
 
-// Find icons from doc using csspaths
+// Find icons from doc using goquery
 func extractIconTags(doc *goquery.Document) []string {
 	var hits []string
 	doc.Find("link[href][rel]").Each(func(i int, s *goquery.Selection) {

--- a/besticon/extract_test.go
+++ b/besticon/extract_test.go
@@ -1,0 +1,61 @@
+package besticon
+
+import (
+	"sort"
+	"testing"
+)
+
+func mustFindIconLinks(html []byte) []string {
+	doc, e := docFromHTML(html)
+	check(e)
+	links := extractIconTags(doc)
+	sort.Strings(links)
+	return links
+}
+
+func TestLinkExtraction(t *testing.T) {
+	// invalid links
+	invalid := []string{
+		"<link rel='nope'>",
+		"<link rel='icon'>",
+		"<link rel='icon' href=''>",
+		"<link rel='xxiconxx' href='a.png'>",
+	}
+	for _, html := range invalid {
+		links := mustFindIconLinks([]byte(html))
+		if len(links) != 0 {
+			t.Fatalf("%s shouldn't contain links", html)
+		}
+	}
+
+	// test rel case
+	valid := []string{
+		"<link rel='icon' href='xx'>",
+		"<link rel='shortcut icon' href='xx'>",
+		"<link REL='Shortcut Icon' href='xx'>",
+		"<link rel='apple-touch-icon' href='xx'>",
+		"<link rel='apple-touch-icon-precomposed' href='xx'>",
+	}
+	for _, html := range valid {
+		links := mustFindIconLinks([]byte(html))
+		if len(links) != 1 {
+			t.Fatalf("%s should contain one link", html)
+		}
+	}
+
+	// test some files
+	links := mustFindIconLinks(mustReadFile("testdata/daringfireball.html"))
+	assertEquals(t, []string{
+		"/graphics/apple-touch-icon.png",
+		"/graphics/favicon.ico?v=005",
+	}, links)
+	links = mustFindIconLinks(mustReadFile("testdata/newyorker.html"))
+	assertEquals(t, []string{
+		"/wp-content/assets/dist/img/icon/apple-touch-icon-114x114-precomposed.png",
+		"/wp-content/assets/dist/img/icon/apple-touch-icon-144x144-precomposed.png",
+		"/wp-content/assets/dist/img/icon/apple-touch-icon-57x57-precomposed.png",
+		"/wp-content/assets/dist/img/icon/apple-touch-icon-precomposed.png",
+		"/wp-content/assets/dist/img/icon/apple-touch-icon.png",
+		"/wp-content/assets/dist/img/icon/favicon.ico",
+	}, links)
+}


### PR DESCRIPTION
See #48. Use string processing to locate valid icons instead of relying on goquery selectors. Moved into own file and added a few more tests.