### PR TITLE
fix rel regex, add test

### DIFF
--- a/besticon/extract.go
+++ b/besticon/extract.go
@@ -99,7 +99,7 @@ func extractBaseTag(doc *goquery.Document) string {
 
 var (
 	iconTypes   = []string{favIcon, appleTouchIcon, appleTouchIconPrecomposed}
-	iconTypesRe = regexp.MustCompile(fmt.Sprintf(`\b(%s)\b`, strings.Join(regexpQuoteMetaArray(iconTypes), "|")))
+	iconTypesRe = regexp.MustCompile(fmt.Sprintf("^(%s)$", strings.Join(regexpQuoteMetaArray(iconTypes), "|")))
 )
 
 // Find icons from doc using goquery
@@ -123,7 +123,7 @@ func extractIconTag(s *goquery.Selection) string {
 	rel = strings.ToLower(rel)
 
 	var iconType string
-	for _, i := range strings.Split(rel, " ") {
+	for _, i := range strings.Fields(rel) {
 		if iconTypesRe.MatchString(i) {
 			iconType = i
 			break

--- a/besticon/extract_test.go
+++ b/besticon/extract_test.go
@@ -19,6 +19,7 @@ func TestLinkExtraction(t *testing.T) {
 		"<link rel='nope'>",
 		"<link rel='icon'>",
 		"<link rel='icon' href=''>",
+		"<link rel='mask-icon' href='a.png'>",
 		"<link rel='xxiconxx' href='a.png'>",
 	}
 	for _, html := range invalid {


### PR DESCRIPTION
The word boundary check `\b` in the regex doesn't work. This was causing the regex to incorrectly match things like `mask-icon`. Pardon my unfamiliarity with golang quoting and the regex support. I tried raw strings, string addition, etc. but I couldn't make those word boundaries work properly. It's probably moot because we should use `^` and `$` anyway.

I also switched to `strings.Fields` (which I just learned about) :)