### PR TITLE
svg lettericons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test_all: build test test_bench
 test:
 	go test -v github.com/mat/besticon/ico
 	go test -v github.com/mat/besticon/besticon
+	go test -v github.com/mat/besticon/besticon/iconserver
 	go test -v github.com/mat/besticon/lettericon
 	go test -v github.com/mat/besticon/colorfinder
 

--- a/besticon/iconserver/server.go
+++ b/besticon/iconserver/server.go
@@ -162,7 +162,7 @@ func alliconsHandler(w http.ResponseWriter, r *http.Request) {
 func lettericonHandler(w http.ResponseWriter, r *http.Request) {
 	charParam, col, size, format := lettericon.ParseIconPath(r.URL.Path)
 	if charParam == "" || col == nil || size <= 0 || format == "" {
-		writeAPIError(w, 400, errors.New("wrong format for lettericons/ path, must look like lettericons/M-144-EFC25D.png"))
+		writeAPIError(w, 400, errors.New("wrong format for lettericons/ path, must look like lettericons/M-144-EFC25D.png or M-EFC25D.svg"))
 		return
 	}
 

--- a/besticon/iconserver/server.go
+++ b/besticon/iconserver/server.go
@@ -104,7 +104,12 @@ func iconHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	redirectPath := lettericon.IconPath(letter, fmt.Sprintf("%d", sizeRange.Perfect), iconColor)
+	// We support both PNG and SVG fallback. Only return SVG if requested.
+	format := "png"
+	if includesString(finder.FormatsAllowed, "svg") {
+		format = "svg"
+	}
+	redirectPath := lettericon.IconPath(letter, fmt.Sprintf("%d", sizeRange.Perfect), iconColor, format)
 	redirectWithCacheControl(w, r, redirectPath)
 }
 
@@ -155,15 +160,20 @@ func alliconsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func lettericonHandler(w http.ResponseWriter, r *http.Request) {
-	charParam, col, size := lettericon.ParseIconPath(r.URL.Path)
-	if charParam == "" || col == nil || size <= 0 {
+	charParam, col, size, format := lettericon.ParseIconPath(r.URL.Path)
+	if charParam == "" || col == nil || size <= 0 || format == "" {
 		writeAPIError(w, 400, errors.New("wrong format for lettericons/ path, must look like lettericons/M-144-EFC25D.png"))
 		return
 	}
 
-	w.Header().Add(contentType, imagePNG)
+	if format == "svg" {
+		w.Header().Add(contentType, imageSVG)
+		lettericon.RenderSVG(charParam, col, w)
+	} else {
+		w.Header().Add(contentType, imagePNG)
+		lettericon.RenderPNG(charParam, col, size, w)
+	}
 	addCacheControl(w, oneYear)
-	lettericon.Render(charParam, col, size, w)
 }
 
 func writeAPIError(w http.ResponseWriter, httpStatus int, e error) {
@@ -198,6 +208,7 @@ const (
 	contentType     = "Content-Type"
 	applicationJSON = "application/json"
 	imagePNG        = "image/png"
+	imageSVG        = "image/svg+xml"
 )
 
 func renderJSONResponse(w http.ResponseWriter, httpStatus int, data interface{}) {
@@ -430,4 +441,13 @@ func getenvOrFallback(key string, fallbackValue string) string {
 		return value
 	}
 	return fallbackValue
+}
+
+func includesString(arr []string, str string) bool {
+	for _, e := range arr {
+		if e == str {
+			return true
+		}
+	}
+	return false
 }

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -202,7 +202,7 @@ func TestGetLetterIconPNG(t *testing.T) {
 }
 
 func TestGetLetterIconSVG(t *testing.T) {
-	req, err := http.NewRequest("GET", "/lettericons/M-144-EFC25D.svg", nil)
+	req, err := http.NewRequest("GET", "/lettericons/M-EFC25D.svg", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -136,6 +136,19 @@ func TestGet404IconWithInvalidFallbackColor(t *testing.T) {
 	assertStringEquals(t, "/lettericons/H-32.png", w.Header().Get("Location"))
 }
 
+func TestGetIconWithSVG(t *testing.T) {
+	req, err := http.NewRequest("GET", "/icons?size=32&url=httpbin.org/status/404&formats=svg", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	iconHandler(w, req)
+
+	assertStringEquals(t, "302", fmt.Sprintf("%d", w.Code))
+	assertStringEquals(t, "/lettericons/H-32.svg", w.Header().Get("Location"))
+}
+
 func TestGetAllIcons(t *testing.T) {
 	req, err := http.NewRequest("GET", "/allicons.json?url=apple.com", nil)
 	if err != nil {
@@ -173,7 +186,7 @@ func TestGetPopular(t *testing.T) {
 	assertStringContains(t, w.Body.String(), `github.com`)
 }
 
-func TestGetLetterIcon(t *testing.T) {
+func TestGetLetterIconPNG(t *testing.T) {
 	req, err := http.NewRequest("GET", "/lettericons/M-144-EFC25D.png", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -186,6 +199,21 @@ func TestGetLetterIcon(t *testing.T) {
 	assertStringEquals(t, "image/png", w.Header().Get("Content-Type"))
 	assertStringEquals(t, "max-age=31536000", w.Header().Get("Cache-Control"))
 	assertIntegerInInterval(t, 1500, 1800, w.Body.Len())
+}
+
+func TestGetLetterIconSVG(t *testing.T) {
+	req, err := http.NewRequest("GET", "/lettericons/M-144-EFC25D.svg", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	lettericonHandler(w, req)
+
+	assertStringEquals(t, "200", fmt.Sprintf("%d", w.Code))
+	assertStringEquals(t, "image/svg+xml", w.Header().Get("Content-Type"))
+	assertStringEquals(t, "max-age=31536000", w.Header().Get("Cache-Control"))
+	assertStringContains(t, w.Body.String(), `<svg`)
 }
 
 func TestGetBadLetterIconPath(t *testing.T) {

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -146,7 +146,7 @@ func TestGetIconWithSVG(t *testing.T) {
 	iconHandler(w, req)
 
 	assertStringEquals(t, "302", fmt.Sprintf("%d", w.Code))
-	assertStringEquals(t, "/lettericons/H-32.svg", w.Header().Get("Location"))
+	assertStringEquals(t, "/lettericons/H.svg", w.Header().Get("Location"))
 }
 
 func TestGetAllIcons(t *testing.T) {

--- a/lettericon/lettericon.go
+++ b/lettericon/lettericon.go
@@ -183,16 +183,27 @@ func ColorFromHex(hex string) (*color.RGBA, error) {
 }
 
 func IconPath(letter string, size string, colr *color.RGBA, format string) string {
+	var parts []string
+
+	// letter
 	if letter == "" {
 		letter = " "
 	} else {
 		letter = strings.ToUpper(letter)
 	}
+	parts = append(parts, letter)
 
-	if colr != nil {
-		return fmt.Sprintf("/lettericons/%s-%s-%s.%s", letter, size, colorfinder.ColorToHex(*colr), format)
+	// size (maybe)
+	if format == "png" {
+		parts = append(parts, size)
 	}
-	return fmt.Sprintf("/lettericons/%s-%s.%s", letter, size, format)
+
+	// colr (maybe)
+	if colr != nil {
+		parts = append(parts, colorfinder.ColorToHex(*colr))
+	}
+
+	return fmt.Sprintf("/lettericons/%s.%s", strings.Join(parts, "-"), format)
 }
 
 const defaultIconSize = 144

--- a/lettericon/lettericon.go
+++ b/lettericon/lettericon.go
@@ -2,6 +2,8 @@ package lettericon
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"image"
@@ -30,7 +32,7 @@ const dpi = 72
 const fontSizeFactor = 0.6180340     // (by taste)
 const yOffsetFactor = 102.0 / 1024.0 // (by trial and error) :-)
 
-func Render(letter string, bgColor color.Color, width int, out io.Writer) error {
+func RenderPNG(letter string, bgColor color.Color, width int, out io.Writer) error {
 	fg := pickForegroundColor(bgColor)
 
 	rgba := image.NewRGBA(image.Rect(0, 0, width, width))
@@ -193,6 +195,7 @@ func IconPath(letter string, size string, colr *color.RGBA) string {
 }
 
 const defaultIconSize = 144
+
 // TODO: Sync with besticon.MaxIconSize ?
 const maxIconSize = 256
 
@@ -279,6 +282,45 @@ func percentDecode(p string) string {
 		return p
 	}
 	return u.Path
+}
+
+const svgTemplate = `
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100" height="100" fill="$BG_COLOR"/>
+  <text x="50%" y="50%" dy="0.10em" font-family="Helvetica Neue, Helvetica, sans-serif" font-size="75" dominant-baseline="middle" text-anchor="middle" fill="$FG_COLOR">$LETTER</text>
+</svg>
+`
+
+// RenderSVG writes an SVG lettericon for this letter and color
+func RenderSVG(letter string, bgColor color.Color, out io.Writer) error {
+	// xml escape letter
+	var buf bytes.Buffer
+	err := xml.EscapeText(&buf, []byte(letter))
+	if err != nil {
+		return err
+	}
+
+	// vars
+	vars := map[string]string{
+		"$BG_COLOR": ColorToHex(bgColor),
+		"$FG_COLOR": ColorToHex(pickForegroundColor(bgColor)),
+		"$LETTER":   buf.String(),
+	}
+
+	// render SVG by replacing vars in template
+	svg := strings.TrimSpace(svgTemplate) + "\n"
+	for k, v := range vars {
+		svg = strings.ReplaceAll(svg, k, v)
+	}
+
+	_, err = io.WriteString(out, svg)
+	return err
+}
+
+// ColorToHex returns the #rrggbb hex string for a color
+func ColorToHex(c color.Color) string {
+	r, g, b, _ := c.RGBA()
+	return fmt.Sprintf("#%02x%02x%02x", r&0xff, g&0xff, b&0xff)
 }
 
 var fnt *truetype.Font

--- a/lettericon/lettericon.go
+++ b/lettericon/lettericon.go
@@ -217,7 +217,7 @@ func ParseIconPath(fullpath string) (string, *color.RGBA, int, string) {
 
 	_, filename := path.Split(fullpath)
 
-	// what is the format?
+	// format
 	format := filepath.Ext(filename)
 	if !(format == ".png" || format == ".svg") {
 		return "", nil, -1, ""
@@ -225,35 +225,51 @@ func ParseIconPath(fullpath string) (string, *color.RGBA, int, string) {
 	filename = strings.TrimSuffix(filename, format)
 	format = format[1:] // remove period
 
+	// now we parse each of the params, delimited by "-"
 	params := strings.Split(filename, "-")
-	if len(params) < 1 || len(params[0]) < 1 {
+	if len(params) == 0 {
 		return "", nil, -1, ""
 	}
-
-	charParam := firstRune(params[0])
-	sizeParam := ""
-	if len(params) >= 2 {
-		sizeParam = params[1]
-	}
-	colorParam := ""
-	if len(params) >= 3 {
-		colorParam = params[2]
+	for _, s := range params {
+		if len(s) == 0 {
+			return "", nil, -1, ""
+		}
 	}
 
-	size, err := strconv.Atoi(sizeParam)
-	if err != nil || size < 0 {
+	var letter string
+	var size int
+	var col *color.RGBA
+
+	// letter
+	letter, params = firstRune(params[0]), params[1:]
+
+	// size (only png)
+	if format == "png" && len(params) > 0 {
+		size, _ = strconv.Atoi(params[0])
+		params = params[1:]
+	}
+	if size < 1 {
 		size = defaultIconSize
 	}
 	if size > maxIconSize {
 		size = maxIconSize
 	}
 
-	col, _ := ColorFromHex(colorParam)
+	// color
+	if len(params) > 0 {
+		col, _ = ColorFromHex(params[0])
+		params = params[1:]
+	}
 	if col == nil {
 		col = DefaultBackgroundColor
 	}
 
-	return charParam, col, size, format
+	// extra stuff at the end? error
+	if len(params) > 0 {
+		return "", nil, -1, ""
+	}
+
+	return letter, col, size, format
 }
 
 func MainLetterFromURL(URL string) string {

--- a/lettericon/lettericon/cmd.go
+++ b/lettericon/lettericon/cmd.go
@@ -31,7 +31,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = lettericon.Render(*letter, col, *width, f)
+	err = lettericon.RenderPNG(*letter, col, *width, f)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/lettericon/lettericon_test.go
+++ b/lettericon/lettericon_test.go
@@ -131,7 +131,7 @@ func renderPNGBytes(letter string, bgColor color.Color, width int) ([]byte, erro
 	return b.Bytes(), nil
 }
 
-func BenchmarkRender(b *testing.B) {
+func BenchmarkRenderPNG(b *testing.B) {
 	RenderPNG("X", DefaultBackgroundColor, 144, ioutil.Discard) // warmup
 	b.ResetTimer()
 
@@ -156,46 +156,50 @@ func TestMainLetterFromURL(t *testing.T) {
 }
 
 func TestIconPath(t *testing.T) {
-	assertEquals(t, "/lettericons/A-120-000000.png", IconPath("a", "120", &color.RGBA{0, 0, 0, 0}))
-	assertEquals(t, "/lettericons/Z-100-640ac8.png", IconPath("z", "100", &color.RGBA{100, 10, 200, 0}))
+	assertEquals(t, "/lettericons/A-120-000000.png", IconPath("a", "120", &color.RGBA{0, 0, 0, 0}, "png"))
+	assertEquals(t, "/lettericons/Z-100-640ac8.svg", IconPath("z", "100", &color.RGBA{100, 10, 200, 0}, "svg"))
 }
 
 func TestParseIconPath(t *testing.T) {
 	var char string
 	var col *color.RGBA
 	var size int
+	var format string
 
-	char, _, _ = ParseIconPath("lettericons/")
+	char, _, _, _ = ParseIconPath("lettericons/")
 	assertEquals(t, "", char)
 
-	char, _, _ = ParseIconPath("lettericons/A")
-	assertEquals(t, "A", char)
-
-	char, _, _ = ParseIconPath("lettericons/B.png")
+	char, _, _, _ = ParseIconPath("lettericons/B.png")
 	assertEquals(t, "B", char)
 
-	char, _, size = ParseIconPath("lettericons/C-120.png")
+	char, _, size, _ = ParseIconPath("lettericons/C-120.png")
 	assertEquals(t, "C", char)
 	assertEquals(t, 120, size)
 
-	char, _, size = ParseIconPath("lettericons/%D1%84-120.png") //ф-120.png
+	char, _, size, _ = ParseIconPath("lettericons/%D1%84-120.png") //ф-120.png
 	assertEquals(t, `ф`, char)
 	assertEquals(t, 120, size)
 
-	char, col, size = ParseIconPath("lettericons/D-150-ababab.png")
+	char, col, size, _ = ParseIconPath("lettericons/D-150-ababab.png")
 	assertEquals(t, "D", char)
 	assertEquals(t, 150, size)
 	assertEquals(t, &color.RGBA{171, 171, 171, 0xff}, col)
 
-	char, col, size = ParseIconPath("lettericons/D-256-ababab.png")
+	char, col, size, _ = ParseIconPath("lettericons/D-256-ababab.png")
 	assertEquals(t, "D", char)
 	assertEquals(t, 256, size)
 	assertEquals(t, &color.RGBA{171, 171, 171, 0xff}, col)
 
-	char, col, size = ParseIconPath("lettericons/D-1024-ababab.png")
+	char, col, size, _ = ParseIconPath("lettericons/D-1024-ababab.png")
 	assertEquals(t, "D", char)
 	assertEquals(t, 256, size)
 	assertEquals(t, &color.RGBA{171, 171, 171, 0xff}, col)
+
+	// test format
+	_, _, _, format = ParseIconPath("lettericons/B.png")
+	assertEquals(t, "png", format)
+	_, _, _, format = ParseIconPath("lettericons/B.svg")
+	assertEquals(t, "svg", format)
 }
 
 func assertColor(t *testing.T, hexColor string, expectedColor color.Color) {

--- a/lettericon/lettericon_test.go
+++ b/lettericon/lettericon_test.go
@@ -157,7 +157,7 @@ func TestMainLetterFromURL(t *testing.T) {
 
 func TestIconPath(t *testing.T) {
 	assertEquals(t, "/lettericons/A-120-000000.png", IconPath("a", "120", &color.RGBA{0, 0, 0, 0}, "png"))
-	assertEquals(t, "/lettericons/Z-100-640ac8.svg", IconPath("z", "100", &color.RGBA{100, 10, 200, 0}, "svg"))
+	assertEquals(t, "/lettericons/Z-640ac8.svg", IconPath("z", "100", &color.RGBA{100, 10, 200, 0}, "svg"))
 }
 
 func TestParseIconPath(t *testing.T) {

--- a/lettericon/lettericon_test.go
+++ b/lettericon/lettericon_test.go
@@ -169,8 +169,9 @@ func TestParseIconPath(t *testing.T) {
 	char, _, _, _ = ParseIconPath("lettericons/")
 	assertEquals(t, "", char)
 
-	char, _, _, _ = ParseIconPath("lettericons/B.png")
+	char, _, _, format = ParseIconPath("lettericons/B.png")
 	assertEquals(t, "B", char)
+	assertEquals(t, "png", format)
 
 	char, _, size, _ = ParseIconPath("lettericons/C-120.png")
 	assertEquals(t, "C", char)
@@ -195,11 +196,34 @@ func TestParseIconPath(t *testing.T) {
 	assertEquals(t, 256, size)
 	assertEquals(t, &color.RGBA{171, 171, 171, 0xff}, col)
 
-	// test format
-	_, _, _, format = ParseIconPath("lettericons/B.png")
-	assertEquals(t, "png", format)
-	_, _, _, format = ParseIconPath("lettericons/B.svg")
+	// svg
+	char, _, _, format = ParseIconPath("lettericons/B.svg")
+	assertEquals(t, "B", char)
 	assertEquals(t, "svg", format)
+
+	// svg with color
+	char, col, _, format = ParseIconPath("lettericons/D-ababab.svg")
+	assertEquals(t, "D", char)
+	assertEquals(t, &color.RGBA{171, 171, 171, 0xff}, col)
+	assertEquals(t, "svg", format)
+}
+
+func TestBadIconPaths(t *testing.T) {
+	invalid := []string{
+		"",
+		"A",
+		"---",
+		"-A-",
+		"A--",
+		"A--.svg",
+		"A-11-ababab.svg",       // size not allowed
+		"A-11-ababab-bogus.png", // extra param
+	}
+
+	for _, s := range invalid {
+		char, _, _, _ := ParseIconPath(fmt.Sprintf("lettericons/%s", s))
+		assertEquals(t, "", char)
+	}
 }
 
 func assertColor(t *testing.T, hexColor string, expectedColor color.Color) {
@@ -211,6 +235,7 @@ func assertColor(t *testing.T, hexColor string, expectedColor color.Color) {
 
 	assertEquals(t, expectedColor, actualColor)
 }
+
 func assertEquals(t *testing.T, expected, actual interface{}) {
 	if !reflect.DeepEqual(expected, actual) {
 		fail(t, fmt.Sprintf("Not equal: %v (expected)\n"+

--- a/lettericon/testdata/A-123456.svg
+++ b/lettericon/testdata/A-123456.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100" height="100" fill="#123456"/>
+  <text x="50%" y="50%" dy="0.10em" font-family="Helvetica Neue, Helvetica, sans-serif" font-size="75" dominant-baseline="middle" text-anchor="middle" fill="#ffffff">A</text>
+</svg>

--- a/lettericon/testdata/X-dfdfdf.svg
+++ b/lettericon/testdata/X-dfdfdf.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100" height="100" fill="#123456"/>
+  <text x="50%" y="50%" dy="0.10em" font-family="Helvetica Neue, Helvetica, sans-serif" font-size="75" dominant-baseline="middle" text-anchor="middle" fill="#ffffff">X</text>
+</svg>

--- a/lettericon/testdata/ф-dfdfdf.svg
+++ b/lettericon/testdata/ф-dfdfdf.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100" height="100" fill="#123456"/>
+  <text x="50%" y="50%" dy="0.10em" font-family="Helvetica Neue, Helvetica, sans-serif" font-size="75" dominant-baseline="middle" text-anchor="middle" fill="#ffffff">ф</text>
+</svg>


### PR DESCRIPTION
The server can generate SVG lettericons. Only enabled if `?formats=` includes `svg`. Most of the action is in `RenderSVG`. Also tweaks to `IconPath` to support SVG. For example, an SVG lettericon path doesn't include the size in the filename.

One thing to note. The A-Z lettericons look great (see below), but ф is a bit low. Right now we have `dy="0.10em"` hardcoded in the SVG template. Not sure if it would be possible/worthwhile to customize based on the letter. I could also imagine using Freetype to measure the Arial glyph height... The traco 1M doesn't include any IDN domains, unfortunately.

![image](https://user-images.githubusercontent.com/526195/109394978-c817ae00-78de-11eb-939d-01a7b5d90a5f.png)

