### PR TITLE
Disable pprof by default

### DIFF
--- a/besticon/iconserver/server.go
+++ b/besticon/iconserver/server.go
@@ -8,8 +8,6 @@ import (
 	"html/template"
 	"io"
 	"net/http"
-	// Enable runtime profiling at /debug/pprof
-	_ "net/http/pprof"
 	"net/url"
 	"os"
 	"runtime"


### PR DESCRIPTION
pprof was always enabled and could not be disabled without
compiling different source code. This disables pprof by default
by using a different ServeMux for serving all endpoints, and only
delegating to the default HTTP ServeMux when pprof is explicitly
enabled.