### PR TITLE
Trying to fix correct version pull

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -91,11 +91,11 @@ Binaries for some operating systems can be downloaded from <https://github.com/m
 
 If you have Go installed on your system you can use `go get` to fetch the source code and build the server:
 
-    $ go get -u github.com/mat/besticon/...
+    $ go get -u github.com/mat/besticon/v3
 
 If you want to build executables for a different target operating system you can add the `GOOS` and `GOARCH` environment variables:
 
-    $ GOOS=linux GOARCH=amd64 go get -u github.com/mat/besticon/...
+    $ GOOS=linux GOARCH=amd64 go get -u github.com/mat/besticon/v3
 
 ### Running
 

--- a/besticon/besticon.go
+++ b/besticon/besticon.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha1"
 	"errors"
 	"fmt"
-	"github.com/golang/groupcache"
 	"image"
 	"image/color"
 	"io/ioutil"
@@ -16,14 +15,16 @@ import (
 	"os"
 	"strings"
 
+	"github.com/golang/groupcache"
+
 	// Load supported image formats.
 	_ "image/gif"
 	_ "image/jpeg"
 	_ "image/png"
 
-	_ "github.com/mat/besticon/ico"
+	_ "github.com/mat/besticon/v3/ico"
 
-	"github.com/mat/besticon/colorfinder"
+	"github.com/mat/besticon/v3/colorfinder"
 
 	"golang.org/x/net/html/charset"
 )

--- a/besticon/besticon/cmd.go
+++ b/besticon/besticon/cmd.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/mat/besticon/besticon"
+	"github.com/mat/besticon/v3/besticon"
 )
 
 func main() {

--- a/besticon/besticon_test.go
+++ b/besticon/besticon_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mat/besticon/vcr"
+	"github.com/mat/besticon/v3/vcr"
 )
 
 //

--- a/besticon/iconserver/server.go
+++ b/besticon/iconserver/server.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mat/besticon/besticon"
-	"github.com/mat/besticon/besticon/iconserver/assets"
-	"github.com/mat/besticon/lettericon"
+	"github.com/mat/besticon/v3/besticon"
+	"github.com/mat/besticon/v3/besticon/iconserver/assets"
+	"github.com/mat/besticon/v3/lettericon"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mat/besticon/besticon"
+	"github.com/mat/besticon/v3/besticon"
 )
 
 func TestGetIndex(t *testing.T) {

--- a/colorfinder/colorfinder.go
+++ b/colorfinder/colorfinder.go
@@ -21,7 +21,7 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 
-	_ "github.com/mat/besticon/ico"
+	_ "github.com/mat/besticon/v3/ico"
 )
 
 func main() {

--- a/dummy.go
+++ b/dummy.go
@@ -1,0 +1,2 @@
+// Allows for running go get and go mod in the root directory
+package besticon

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mat/besticon
+module github.com/mat/besticon/v3
 
 // +heroku goVersion go1.21
 

--- a/ico/icoparser/icoparser.go
+++ b/ico/icoparser/icoparser.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mat/besticon/ico"
+	"github.com/mat/besticon/v3/ico"
 )
 
 func main() {

--- a/lettericon/lettericon.go
+++ b/lettericon/lettericon.go
@@ -24,8 +24,8 @@ import (
 	"golang.org/x/net/publicsuffix"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/mat/besticon/colorfinder"
-	"github.com/mat/besticon/lettericon/fonts"
+	"github.com/mat/besticon/v3/colorfinder"
+	"github.com/mat/besticon/v3/lettericon/fonts"
 )
 
 const dpi = 72

--- a/lettericon/lettericon/cmd.go
+++ b/lettericon/lettericon/cmd.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/mat/besticon/lettericon"
+	"github.com/mat/besticon/v3/lettericon"
 )
 
 var (


### PR DESCRIPTION
When I tried to pull besticon for integration with my own webserver, I ran into an issue where go would only pull v3.12.0 and would complain about v3 not being valid when I would try to force pull v3.17.0. 

```
go: github.com/mat/besticon/v3@v3.17.0: go.mod has non-.../v3 module path "github.com/mat/besticon" (and .../v3/go.mod does not exist) at revision v3.17.0
```

I was able to verify this PR fixes this issue by replacing besticon/v3 with my fork; this enabled me to pull the latest.