### PR TITLE
Do the go v3 'properly'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,25 @@
 build:
-	go get github.com/mat/besticon/...
-
+	go build ./...
 test_all: build test test_bench
 	go test -v github.com/mat/besticon/besticon/iconserver
 
 test:
-	go test -v github.com/mat/besticon/ico
-	go test -v github.com/mat/besticon/besticon
-	go test -v github.com/mat/besticon/besticon/iconserver
-	go test -v github.com/mat/besticon/lettericon
-	go test -v github.com/mat/besticon/colorfinder
+	go test -v github.com/mat/besticon/v3/ico
+	go test -v github.com/mat/besticon/v3/besticon
+	go test -v github.com/mat/besticon/v3/besticon/iconserver
+	go test -v github.com/mat/besticon/v3/lettericon
+	go test -v github.com/mat/besticon/v3/colorfinder
 
 test_race:
-	go test -v -race github.com/mat/besticon/ico
-	go test -v -race github.com/mat/besticon/besticon
-	go test -v -race github.com/mat/besticon/besticon/iconserver
-	go test -v -race github.com/mat/besticon/lettericon
-	go test -v -race github.com/mat/besticon/colorfinder
+	go test -v -race github.com/mat/besticon/v3/ico
+	go test -v -race github.com/mat/besticon/v3/besticon
+	go test -v -race github.com/mat/besticon/v3/besticon/iconserver
+	go test -v -race github.com/mat/besticon/v3/lettericon
+	go test -v -race github.com/mat/besticon/v3/colorfinder
 
 test_bench:
-	go test github.com/mat/besticon/lettericon -bench .
-	go test github.com/mat/besticon/colorfinder -bench .
+	go test github.com/mat/besticon/v3/lettericon -bench .
+	go test github.com/mat/besticon/v3/colorfinder -bench .
 
 deploy:
 	git push heroku master
@@ -30,17 +29,17 @@ install:
 	go get ./...
 
 run_server:
-	go build -o bin/iconserver github.com/mat/besticon/besticon/iconserver
+	go build -o bin/iconserver github.com/mat/besticon/v3/besticon/iconserver
 	PORT=3000 DEPLOYED_AT=`date +%s` HOST_ONLY_DOMAINS=* POPULAR_SITES=bing.com,github.com,instagram.com,reddit.com ./bin/iconserver
 
 coverage_besticon:
-	go test -coverprofile=coverage.out -covermode=count github.com/mat/besticon/besticon && go tool cover -html=coverage.out && unlink coverage.out
+	go test -coverprofile=coverage.out -covermode=count github.com/mat/besticon/v3/besticon && go tool cover -html=coverage.out && unlink coverage.out
 
 coverage_ico:
-	go test -coverprofile=coverage.out -covermode=count github.com/mat/besticon/ico && go tool cover -html=coverage.out && unlink coverage.out
+	go test -coverprofile=coverage.out -covermode=count github.com/mat/besticon/v3/ico && go tool cover -html=coverage.out && unlink coverage.out
 
 coverage_iconserver:
-	go test -coverprofile=coverage.out -covermode=count github.com/mat/besticon/besticon/iconserver && go tool cover -html=coverage.out && unlink coverage.out
+	go test -coverprofile=coverage.out -covermode=count github.com/mat/besticon/v3/besticon/iconserver && go tool cover -html=coverage.out && unlink coverage.out
 
 test_websites:
 	go get ./...
@@ -61,16 +60,16 @@ clean:
 	rm -f iconserver*.zip
 
 build_darwin_amd64:
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o bin/darwin_amd64/iconserver -ldflags "-X github.com/mat/besticon/besticon.BuildDate=`date +'%Y-%m-%d'`" github.com/mat/besticon/besticon/iconserver
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o bin/darwin_amd64/iconserver -ldflags "-X github.com/mat/besticon/v3/besticon.BuildDate=`date +'%Y-%m-%d'`" github.com/mat/besticon/besticon/iconserver
 
 build_linux_amd64:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o bin/linux_amd64/iconserver -ldflags "-X github.com/mat/besticon/besticon.BuildDate=`date +'%Y-%m-%d'`" github.com/mat/besticon/besticon/iconserver
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o bin/linux_amd64/iconserver -ldflags "-X github.com/mat/besticon/v3/besticon.BuildDate=`date +'%Y-%m-%d'`" github.com/mat/besticon/besticon/iconserver
 
 build_linux_arm64:
-	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -a -installsuffix cgo -o bin/linux_arm64/iconserver -ldflags "-X github.com/mat/besticon/besticon.BuildDate=`date +'%Y-%m-%d'`" github.com/mat/besticon/besticon/iconserver
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -a -installsuffix cgo -o bin/linux_arm64/iconserver -ldflags "-X github.com/mat/besticon/v3/besticon.BuildDate=`date +'%Y-%m-%d'`" github.com/mat/besticon/besticon/iconserver
 
 build_windows_amd64:
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o bin/windows_amd64/iconserver.exe -ldflags "-X github.com/mat/besticon/besticon.BuildDate=`date +'%Y-%m-%d'`" github.com/mat/besticon/besticon/iconserver
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -o bin/windows_amd64/iconserver.exe -ldflags "-X github.com/mat/besticon/v3/besticon.BuildDate=`date +'%Y-%m-%d'`" github.com/mat/besticon/besticon/iconserver
 
 build_all_platforms: build_darwin_amd64 build_linux_amd64 build_linux_arm64 build_windows_amd64
 	find bin/ -type file | xargs file

--- a/besticon/besticon.go
+++ b/besticon/besticon.go
@@ -21,9 +21,9 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 
-	_ "github.com/mat/besticon/ico"
+	_ "github.com/mat/besticon/v3/ico"
 
-	"github.com/mat/besticon/colorfinder"
+	"github.com/mat/besticon/v3/colorfinder"
 
 	"golang.org/x/net/html/charset"
 )

--- a/besticon/besticon/cmd.go
+++ b/besticon/besticon/cmd.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/mat/besticon/besticon"
+	"github.com/mat/besticon/v3/besticon"
 )
 
 func main() {

--- a/besticon/besticon_test.go
+++ b/besticon/besticon_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/mat/besticon/vcr"
+	"github.com/mat/besticon/v3/vcr"
 )
 
 //

--- a/besticon/iconserver/server.go
+++ b/besticon/iconserver/server.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mat/besticon/besticon"
-	"github.com/mat/besticon/besticon/iconserver/assets"
-	"github.com/mat/besticon/lettericon"
+	"github.com/mat/besticon/v3/besticon"
+	"github.com/mat/besticon/v3/besticon/iconserver/assets"
+	"github.com/mat/besticon/v3/lettericon"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"

--- a/besticon/iconserver/server_test.go
+++ b/besticon/iconserver/server_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mat/besticon/besticon"
+	"github.com/mat/besticon/v3/besticon"
 )
 
 func TestGetIndex(t *testing.T) {

--- a/colorfinder/colorfinder.go
+++ b/colorfinder/colorfinder.go
@@ -21,7 +21,7 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 
-	_ "github.com/mat/besticon/ico"
+	_ "github.com/mat/besticon/v3/ico"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mat/besticon
+module github.com/mat/besticon/v3
 
 // +heroku goVersion go1.21
 

--- a/ico/icoparser/icoparser.go
+++ b/ico/icoparser/icoparser.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mat/besticon/ico"
+	"github.com/mat/besticon/v3/ico"
 )
 
 func main() {

--- a/lettericon/lettericon.go
+++ b/lettericon/lettericon.go
@@ -24,8 +24,8 @@ import (
 	"golang.org/x/net/publicsuffix"
 
 	"github.com/golang/freetype/truetype"
-	"github.com/mat/besticon/colorfinder"
-	"github.com/mat/besticon/lettericon/fonts"
+	"github.com/mat/besticon/v3/colorfinder"
+	"github.com/mat/besticon/v3/lettericon/fonts"
 )
 
 const dpi = 72

--- a/lettericon/lettericon/cmd.go
+++ b/lettericon/lettericon/cmd.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/mat/besticon/lettericon"
+	"github.com/mat/besticon/v3/lettericon"
 )
 
 var (


### PR DESCRIPTION
This is the bare minimum required to properly support go module versioning above v1: https://go.dev/doc/modules/major-version