### PR TITLE
Add OCI annotations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,8 @@ jobs:
           run: |
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
+              --build-arg VERSION="$VERSION" \
+              --build-arg REVISION="$GITHUB_SHA" \
               -t matthiasluedtke/iconserver:latest \
-              -t matthiasluedtke/iconserver:${{ env.VERSION }} \
+              -t "matthiasluedtke/iconserver:$VERSION" \
               --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 # Adapted from
 # https://cloud.google.com/run/docs/quickstarts/build-and-deploy#containerizing
 
-# Use the offical Golang image to create a build artifact.
+# Use the official Golang image to create a build artifact.
 # https://hub.docker.com/_/golang
 FROM golang:1.23 as builder
+
+LABEL org.opencontainers.image.source="https://github.com/mat/besticon"
+LABEL org.opencontainers.image.licenses="MIT"
 
 # Copy local code to the container image.
 WORKDIR /app
@@ -43,6 +46,12 @@ ENV HTTP_USER_AGENT=''
 ENV POPULAR_SITES=bing.com,github.com,instagram.com,reddit.com
 ENV PORT=8080
 ENV SERVER_MODE=redirect
+
+ARG VERSION=''
+ARG REVISION=''
+
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${REVISION}"
 
 # Run the web service on container startup.
 CMD ["/iconserver"]


### PR DESCRIPTION
Adds labels for some of [the pre-defined annotation of the OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/main/annotations.md). The main use case I have for this personally is that [Renovate uses the value of the `org.opencontainers.image.source` label](https://docs.renovatebot.com/modules/datasource/docker/) to link to a docker based dependency and to look up changelogs.

This makes it easier to see what has changed and to update the image.

I also added labels for version, revision, and license. But there are other ones that can be added as well.

I put the labels with static values at the top, since they will seldom/never change (and can be included in cached layers of the docker build), while the labels that will change often towards the bottom.