### PR TITLE
Fix OCI annotations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.23 as builder
 
-LABEL org.opencontainers.image.source="https://github.com/mat/besticon"
-LABEL org.opencontainers.image.licenses="MIT"
-
 # Copy local code to the container image.
 WORKDIR /app
 COPY . .
@@ -50,6 +47,8 @@ ENV SERVER_MODE=redirect
 ARG VERSION=''
 ARG REVISION=''
 
+LABEL org.opencontainers.image.source="https://github.com/mat/besticon"
+LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.revision="${REVISION}"
 


### PR DESCRIPTION
Follow up to: https://github.com/mat/besticon/pull/107

I realized that the two labels at the top were set on the builder stage and not included in the distributed image. Moving them should fix this.